### PR TITLE
Fix: Create data/preds/$MODEL before writing outputs in run.predict.sh

### DIFF
--- a/scripts/evaluation/run.predict.sh
+++ b/scripts/evaluation/run.predict.sh
@@ -6,7 +6,7 @@ SET=$3 # dev test
 
 for seed in 3477689 4213916 8749520 6828303 9364029
 do
-    mkdir -p data/$MODEL
+    mkdir -p data/preds/$MODEL
     python3 ~/SkillSpan/machamp/predict.py logs/skill.$MODEL.$TYPE.$seed/*/model.pt data/conll/corpus_house_$SET.conll data/preds/$MODEL/$TYPE.house.$SET.$seed.out \
     --dataset house
 


### PR DESCRIPTION
The script failed because it created `data/$MODEL` instead of `data/preds/$MODEL`, causing errors when writing output files.
This fix ensures the correct directory exists by using:

```bash
mkdir -p data/preds/$MODEL
```